### PR TITLE
Fixes GetConnector.getOne return type (object)

### DIFF
--- a/lib/classes/GetConnector.d.ts
+++ b/lib/classes/GetConnector.d.ts
@@ -18,7 +18,7 @@ export default class GetConnector extends Connector {
      *
      * @returns the first entry as an Object. If nothing was found returns Null
      */
-    getOne(getConnectorName: string, config?: IFilterConfig): Promise<TAfasRestDataResponse>;
+    getOne(getConnectorName: string, config?: IFilterConfig): Promise<object>;
     /**
      * Fetch the metadata of a GetConnector
      * If getConnectorName is left empty, gives the list of all connectors, use Profit.metainfo() then instead

--- a/src/classes/GetConnector.ts
+++ b/src/classes/GetConnector.ts
@@ -118,7 +118,7 @@ export default class GetConnector extends Connector {
    * 
    * @returns the first entry as an Object. If nothing was found returns Null
    */
-  public async getOne(getConnectorName: string, config?: IFilterConfig): Promise<TAfasRestDataResponse> {
+  public async getOne(getConnectorName: string, config?: IFilterConfig): Promise<object> {
     try {
       const response = await this.http(this.connectorUrl + getConnectorName + this.parseConfig({...config, skip: 0, take: 1} || {}), 'GET');
       return response.rows[0] || null


### PR DESCRIPTION
Changes the return type of `GetConnector.getOne` from `Promise<TAfasRestDataResponse>` to `Promise<object>`, so one can cast it to a type of own choice without having to cast to `any` first.